### PR TITLE
将翻译head之前修改为<head>内最前面

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <!--
-  以上 2 个 meta 标签 *必须* 放在 head 之前，以确保正确的文档呈现；
+  以上 2 个 meta 标签 *必须* 放在 <head> 标签内 最前面，以确保正确的文档呈现；
   其他任何 head 元素 *必须* 在这些标签之后。
 -->
 <title>页面标题</title>


### PR DESCRIPTION
原文是

> The above 2 meta tags *must* come first in the <head>
  to consistently ensure proper document rendering.
  Any other head element should come *after* these tags.


意思应当这两个meta标签应当是<head>标签*内*前两个标签